### PR TITLE
Add H2 data sources

### DIFF
--- a/simple-app/pom.xml
+++ b/simple-app/pom.xml
@@ -45,6 +45,13 @@
       <artifactId>spring-context</artifactId>
     </dependency>
 
+    <!-- In-memory database for tests -->
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>

--- a/simple-app/src/main/java/com/example/App.java
+++ b/simple-app/src/main/java/com/example/App.java
@@ -1,6 +1,10 @@
 package com.example;
 
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import org.h2.jdbcx.JdbcDataSource;
+import javax.sql.DataSource;
 
 /**
  * Hello world!
@@ -11,5 +15,23 @@ public class App {
     public static void main( String[] args )
     {
         System.out.println( "Hello World!" );
+    }
+
+    @Bean(name = "dataSourceOne")
+    public DataSource dataSourceOne() {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:db1;DB_CLOSE_DELAY=-1");
+        ds.setUser("sa");
+        ds.setPassword("");
+        return ds;
+    }
+
+    @Bean(name = "dataSourceTwo")
+    public DataSource dataSourceTwo() {
+        JdbcDataSource ds = new JdbcDataSource();
+        ds.setURL("jdbc:h2:mem:db2;DB_CLOSE_DELAY=-1");
+        ds.setUser("sa");
+        ds.setPassword("");
+        return ds;
     }
 }

--- a/simple-app/src/test/java/com/example/AppTest.java
+++ b/simple-app/src/test/java/com/example/AppTest.java
@@ -2,9 +2,14 @@ package com.example;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import javax.sql.DataSource;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -13,8 +18,22 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = App.class)
 public class AppTest {
+    @Autowired
+    @Qualifier("dataSourceOne")
+    private DataSource dataSourceOne;
+
+    @Autowired
+    @Qualifier("dataSourceTwo")
+    private DataSource dataSourceTwo;
+
     @Test
     public void testApp() {
         assertTrue(true);
+    }
+
+    @Test
+    public void dataSourcesAreInjected() {
+        assertNotNull(dataSourceOne);
+        assertNotNull(dataSourceTwo);
     }
 }


### PR DESCRIPTION
## Summary
- add H2 runtime dependency
- define two `DataSource` beans in `App`
- inject the data sources in `AppTest`

## Testing
- `mvn test` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687f638f02688329837fd27f089e0ea1