### PR TITLE
Fix H2 compile dependency

### DIFF
--- a/simple-app/pom.xml
+++ b/simple-app/pom.xml
@@ -49,7 +49,6 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <scope>runtime</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
## Summary
- remove runtime scope from H2 dependency to allow compilation

## Testing
- `mvn -q test` *(fails: Non-resolvable import POM)*

------
https://chatgpt.com/codex/tasks/task_e_687f6a1a366c83298fd5935567e59c84