### PR TITLE
Implement simple sharding example

### DIFF
--- a/simple-app/pom.xml
+++ b/simple-app/pom.xml
@@ -44,6 +44,10 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-context</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-jdbc</artifactId>
+    </dependency>
 
     <!-- In-memory database for tests -->
     <dependency>

--- a/simple-app/src/main/java/com/example/App.java
+++ b/simple-app/src/main/java/com/example/App.java
@@ -1,16 +1,21 @@
 package com.example;
 
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 
 import org.h2.jdbcx.JdbcDataSource;
 import javax.sql.DataSource;
+import java.util.HashMap;
+import java.util.Map;
+
 
 /**
  * Hello world!
  *
  */
 @Configuration
+@ComponentScan("com.example")
 public class App {
     public static void main( String[] args )
     {
@@ -32,6 +37,18 @@ public class App {
         ds.setURL("jdbc:h2:mem:db2;DB_CLOSE_DELAY=-1");
         ds.setUser("sa");
         ds.setPassword("");
+        return ds;
+    }
+
+    @Bean(name = "shardingDataSource")
+    public DataSource shardingDataSource() {
+        ShardingRoutingDataSource ds = new ShardingRoutingDataSource();
+        Map<Object, Object> targetDataSources = new HashMap<>();
+        targetDataSources.put("ONE", dataSourceOne());
+        targetDataSources.put("TWO", dataSourceTwo());
+        ds.setTargetDataSources(targetDataSources);
+        ds.setDefaultTargetDataSource(dataSourceOne());
+        ds.afterPropertiesSet();
         return ds;
     }
 }

--- a/simple-app/src/main/java/com/example/Controller.java
+++ b/simple-app/src/main/java/com/example/Controller.java
@@ -1,0 +1,25 @@
+package com.example;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import javax.sql.DataSource;
+
+/**
+ * Simple component acting as a controller in a web application.
+ */
+@Component
+public class Controller {
+
+    private final DataSource dataSource;
+
+    @Autowired
+    public Controller(@Qualifier("shardingDataSource") DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    public DataSource getDataSource() {
+        return dataSource;
+    }
+}

--- a/simple-app/src/main/java/com/example/ShardContext.java
+++ b/simple-app/src/main/java/com/example/ShardContext.java
@@ -1,0 +1,24 @@
+package com.example;
+
+/**
+ * Simple holder for the current shard identifier using {@link ThreadLocal}.
+ */
+public final class ShardContext {
+    private static final ThreadLocal<String> CURRENT_SHARD = new ThreadLocal<>();
+
+    private ShardContext() {
+        // utility class
+    }
+
+    public static void setShard(String shard) {
+        CURRENT_SHARD.set(shard);
+    }
+
+    public static String getShard() {
+        return CURRENT_SHARD.get();
+    }
+
+    public static void clear() {
+        CURRENT_SHARD.remove();
+    }
+}

--- a/simple-app/src/main/java/com/example/ShardingRoutingDataSource.java
+++ b/simple-app/src/main/java/com/example/ShardingRoutingDataSource.java
@@ -1,0 +1,15 @@
+package com.example;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+
+/**
+ * {@link AbstractRoutingDataSource} implementation that routes to a specific
+ * {@link javax.sql.DataSource} based on the {@link ShardContext}.
+ */
+public class ShardingRoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return ShardContext.getShard();
+    }
+}

--- a/simple-app/src/test/java/com/example/AppTest.java
+++ b/simple-app/src/test/java/com/example/AppTest.java
@@ -26,6 +26,13 @@ public class AppTest {
     @Qualifier("dataSourceTwo")
     private DataSource dataSourceTwo;
 
+    @Autowired
+    @Qualifier("shardingDataSource")
+    private DataSource shardingDataSource;
+
+    @Autowired
+    private Controller controller;
+
     @Test
     public void testApp() {
         assertTrue(true);
@@ -35,5 +42,20 @@ public class AppTest {
     public void dataSourcesAreInjected() {
         assertNotNull(dataSourceOne);
         assertNotNull(dataSourceTwo);
+        assertNotNull(shardingDataSource);
+        assertNotNull(controller);
+    }
+
+    @Test
+    public void routingDataSourceWorks() throws Exception {
+        ShardContext.setShard("ONE");
+        try (var conn = shardingDataSource.getConnection()) {
+            assertTrue(conn.getMetaData().getURL().contains("db1"));
+        }
+        ShardContext.setShard("TWO");
+        try (var conn = shardingDataSource.getConnection()) {
+            assertTrue(conn.getMetaData().getURL().contains("db2"));
+        }
+        ShardContext.clear();
     }
 }


### PR DESCRIPTION
## Summary
- add Spring JDBC for routing datasource support
- implement `ShardContext` & `ShardingRoutingDataSource`
- add a `Controller` component using the sharding datasource
- define sharding datasource bean in `App`
- extend tests to verify routing datasource behavior

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_687f868491d483298afa29a4562a4b1b