### PR TITLE
Implement get/post with shard routing

### DIFF
--- a/simple-app/pom.xml
+++ b/simple-app/pom.xml
@@ -56,6 +56,11 @@
     </dependency>
 
     <dependency>
+      <groupId>jakarta.annotation</groupId>
+      <artifactId>jakarta.annotation-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/simple-app/src/test/java/com/example/AppTest.java
+++ b/simple-app/src/test/java/com/example/AppTest.java
@@ -11,6 +11,7 @@ import javax.sql.DataSource;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 /**
  * Unit test for simple App.
@@ -57,5 +58,13 @@ public class AppTest {
             assertTrue(conn.getMetaData().getURL().contains("db2"));
         }
         ShardContext.clear();
+    }
+
+    @Test
+    public void postAndGetWorksAcrossShards() throws Exception {
+        controller.post(100, "even");
+        controller.post(101, "odd");
+        assertEquals("even", controller.get(100));
+        assertEquals("odd", controller.get(101));
     }
 }


### PR DESCRIPTION
## Summary
- add jakarta.annotation-api dependency
- implement `get` and `post` in `Controller`
- initialize `entries` table on startup for both data sources
- test storing and retrieving values per shard

## Testing
- `mvn test -DskipTests=false`

------
https://chatgpt.com/codex/tasks/task_e_688052a7c6fc8329a3d1eef09f4f482c