### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/simple-app"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
## Summary
- configure Dependabot to scan the Maven project under `simple-app`

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_6880eb6d0d0c8329a1c04ccce15fe243