### PR TITLE
Implement annotation-based shard routing

### DIFF
--- a/simple-app/pom.xml
+++ b/simple-app/pom.xml
@@ -56,6 +56,14 @@
       <groupId>org.springframework</groupId>
       <artifactId>spring-tx</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.aspectj</groupId>
+      <artifactId>aspectjweaver</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>ch.qos.logback</groupId>

--- a/simple-app/src/main/java/com/example/AnnotatedService.java
+++ b/simple-app/src/main/java/com/example/AnnotatedService.java
@@ -1,0 +1,79 @@
+package com.example;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.jdbc.datasource.DataSourceUtils;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.sql.DataSource;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+@Service
+public class AnnotatedService {
+
+    private final DataSource dataSource;
+
+    @Autowired
+    public AnnotatedService(@Qualifier("shardingDataSource") DataSource dataSource) {
+        this.dataSource = dataSource;
+    }
+
+    @Transactional
+    @UseDataSourceOne
+    public String getFromOne(int id) throws SQLException {
+        var conn = DataSourceUtils.getConnection(dataSource);
+        try (PreparedStatement ps = conn.prepareStatement("SELECT s FROM entries WHERE id = ?")) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getString(1);
+                }
+                return null;
+            }
+        }
+    }
+
+    @Transactional
+    @UseDataSourceTwo
+    public String getFromTwo(int id) throws SQLException {
+        var conn = DataSourceUtils.getConnection(dataSource);
+        try (PreparedStatement ps = conn.prepareStatement("SELECT s FROM entries WHERE id = ?")) {
+            ps.setInt(1, id);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getString(1);
+                }
+                return null;
+            }
+        }
+    }
+
+    @Transactional
+    @UseDataSourceOne
+    public void postToOne(int id, String s) throws SQLException {
+        var conn = DataSourceUtils.getConnection(dataSource);
+        try (var ps = conn.prepareStatement("INSERT INTO entries(id, s) VALUES(?, ?)")) {
+            ps.setInt(1, id);
+            ps.setString(2, s);
+            ps.executeUpdate();
+        } finally {
+            DataSourceUtils.releaseConnection(conn, dataSource);
+        }
+    }
+
+    @Transactional
+    @UseDataSourceTwo
+    public void postToTwo(int id, String s) throws SQLException {
+        var conn = DataSourceUtils.getConnection(dataSource);
+        try (var ps = conn.prepareStatement("INSERT INTO entries(id, s) VALUES(?, ?)")) {
+            ps.setInt(1, id);
+            ps.setString(2, s);
+            ps.executeUpdate();
+        } finally {
+            DataSourceUtils.releaseConnection(conn, dataSource);
+        }
+    }
+}

--- a/simple-app/src/main/java/com/example/App.java
+++ b/simple-app/src/main/java/com/example/App.java
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityManagerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.orm.jpa.JpaTransactionManager;
 import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
 import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
@@ -22,6 +23,7 @@ import java.util.Map;
 @Configuration
 @ComponentScan("com.example")
 @EnableTransactionManagement
+@EnableAspectJAutoProxy
 public class App {
 
     public static void main(String[] args) {

--- a/simple-app/src/main/java/com/example/Controller.java
+++ b/simple-app/src/main/java/com/example/Controller.java
@@ -13,11 +13,13 @@ public class Controller {
 
     private final Service service;
     private final TxService txService;
+    private final AnnotatedService annotatedService;
 
     @Autowired
-    public Controller(Service service, TxService txService) {
+    public Controller(Service service, TxService txService, AnnotatedService annotatedService) {
         this.service = service;
         this.txService = txService;
+        this.annotatedService = annotatedService;
     }
 
     public String get(int id) throws SQLException {
@@ -26,6 +28,22 @@ public class Controller {
 
     public void post(int id, String s) throws SQLException {
         service.post(id, s);
+    }
+
+    public String getWithAnnotations(int id) throws SQLException {
+        if (id % 2 == 0) {
+            return annotatedService.getFromOne(id);
+        } else {
+            return annotatedService.getFromTwo(id);
+        }
+    }
+
+    public void postWithAnnotations(int id, String s) throws SQLException {
+        if (id % 2 == 0) {
+            annotatedService.postToOne(id, s);
+        } else {
+            annotatedService.postToTwo(id, s);
+        }
     }
 
     public String getWithTransactionTemplate(int id) throws SQLException {

--- a/simple-app/src/main/java/com/example/ShardContextAspect.java
+++ b/simple-app/src/main/java/com/example/ShardContextAspect.java
@@ -1,0 +1,31 @@
+package com.example;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.stereotype.Component;
+
+@Aspect
+@Component
+public class ShardContextAspect {
+
+    @Around("@annotation(com.example.UseDataSourceOne) || @within(com.example.UseDataSourceOne)")
+    public Object useOne(ProceedingJoinPoint pjp) throws Throwable {
+        ShardContext.setShard("ONE");
+        try {
+            return pjp.proceed();
+        } finally {
+            ShardContext.clear();
+        }
+    }
+
+    @Around("@annotation(com.example.UseDataSourceTwo) || @within(com.example.UseDataSourceTwo)")
+    public Object useTwo(ProceedingJoinPoint pjp) throws Throwable {
+        ShardContext.setShard("TWO");
+        try {
+            return pjp.proceed();
+        } finally {
+            ShardContext.clear();
+        }
+    }
+}

--- a/simple-app/src/main/java/com/example/UseDataSourceOne.java
+++ b/simple-app/src/main/java/com/example/UseDataSourceOne.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface UseDataSourceOne {
+}

--- a/simple-app/src/main/java/com/example/UseDataSourceTwo.java
+++ b/simple-app/src/main/java/com/example/UseDataSourceTwo.java
@@ -1,0 +1,13 @@
+package com.example;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Inherited
+public @interface UseDataSourceTwo {
+}

--- a/simple-app/src/test/java/com/example/AppTest.java
+++ b/simple-app/src/test/java/com/example/AppTest.java
@@ -83,4 +83,12 @@ public class AppTest {
         assertEquals("even-tx", controller.getWithTransactionTemplate(200));
         assertEquals("odd-tx", controller.getWithTransactionTemplate(201));
     }
+
+    @Test
+    public void postAndGetWithAnnotations() throws Exception {
+        controller.postWithAnnotations(300, "even-ann");
+        controller.postWithAnnotations(301, "odd-ann");
+        assertEquals("even-ann", controller.getWithAnnotations(300));
+        assertEquals("odd-ann", controller.getWithAnnotations(301));
+    }
 }


### PR DESCRIPTION
## Summary
- add Spring AOP dependency and enable AspectJ proxies
- create `UseDataSourceOne`/`UseDataSourceTwo` annotations
- add `ShardContextAspect` that sets the shard according to annotations
- implement `AnnotatedService` with methods annotated for each datasource
- update `Controller` to delegate based on id parity
- test new annotation-based approach

## Testing
- `mvn test`

------
https://chatgpt.com/codex/tasks/task_e_6880f8faf5f08329b5e2ae16090cd9b4